### PR TITLE
Update README files with force-rebase documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,18 @@ A set of tools that use local LLM (via Ollama) to improve Git workflows without 
 - `cli/llm_commit` - Generate meaningful commit messages using a local LLM
 - `cli/llm_pr` - Create high-quality PR descriptions using a local LLM
 - `cli/llm_setup` - Setup script for checking dependencies and downloading models
+- `cli/claude_commit` - Generate commit messages using Claude API
 
 [Read more about the LLM Git Tools](cli/README-llm-git.md)
+
+### Repository Management Tools
+
+Tools for managing multiple repositories and streamlining development workflows.
+
+- `cli/update-core-repos.sh` - Update multiple repositories, pulling latest master and rebasing branches
+- `cli/review-prs.sh` - Script for reviewing and managing pull requests
+
+[Read more about the Repo Updater](cli/README-update-core-repos.md)
 
 ## Installation
 
@@ -29,6 +39,20 @@ A set of tools that use local LLM (via Ollama) to improve Git workflows without 
    ./llm_setup
    ```
 
+3. Add tool aliases to your .zshrc/.bashrc (examples):
+   ```bash
+   # PR Status Script
+   alias -g prr="~/code/personal-dev-tools/cli/review-prs.sh"
+   # Local LLM Git Tools
+   alias -g ggc="~/code/personal-dev-tools/cli/llm_commit"
+   alias -g ggpr="~/code/personal-dev-tools/cli/llm_pr"
+   alias -g lsu="~/code/personal-dev-tools/cli/llm_setup"
+   # Repo update script
+   alias -g pru="~/code/personal-dev-tools/cli/update-core-repos.sh"
+   # Claude integration
+   alias -g cc="~/code/personal-dev-tools/cli/claude_commit"
+   ```
+
 ## Requirements
 
 Different tools have different requirements. See the specific tool's README for details.
@@ -38,3 +62,12 @@ For the LLM Git Tools:
 - Python 3.6+
 - [Ollama](https://ollama.ai/) for local LLM inference
 - GitHub CLI (`gh`) for PR creation
+
+For the Claude integration:
+- Anthropic Claude API key
+- Python 3.6+
+- `anthropic` Python package
+
+For the Repository Management Tools:
+- Git
+- GitHub CLI (`gh`) for PR management

--- a/cli/README-update-core-repos.md
+++ b/cli/README-update-core-repos.md
@@ -17,6 +17,9 @@ pru -a
 # Update but don't force push rebased branches
 pru -n
 
+# Force rebase even if master hasn't changed
+pru -f
+
 # Generate example config files
 pru -g
 
@@ -30,6 +33,7 @@ pru -h
 - Automatically pulls latest changes from master branch
 - Auto-stashes uncommitted changes before switching/pulling
 - Selectively rebases specific branches based on config file
+- Intelligently skips rebasing when master hasn't changed (with force option available)
 - Automatically force pushes successfully rebased branches
 - Option to stay on master branch after update
 - Detailed reporting of actions and results
@@ -79,6 +83,9 @@ ASK_BEFORE_SWITCH="false"
 
 # Set to 'true' to force push successfully rebased branches to origin
 FORCE_PUSH="true"
+
+# Set to 'true' to force rebase even if master didn't change
+FORCE_REBASE="false"
 ```
 
 ## Usage Options
@@ -91,12 +98,15 @@ Options:
   -r, --rebase    Specify a custom rebase file
   -g, --generate  Generate example config files and exit
   -n, --no-push   Don't force push rebased branches to origin
+  -c, --no-clean  Don't prompt for cleaning untracked branches
+  -f, --force     Force rebase even if master didn't change
   -h, --help      Display this help message
 ```
 
 ## Safety Features
 
 - Never rebases master/main branches (protected)
+- Skips unnecessary rebases when master hasn't changed
 - Auto-stashing of uncommitted changes
 - Automatic conflict detection and abort
 - Rebase and push are treated as separate operations
@@ -139,4 +149,7 @@ pru /path/to/ci-repos.txt
 
 # Non-interactive mode (never force push)
 pru -n /path/to/ci-repos.txt
+
+# Force rebasing even if master hasn't changed
+pru -f
 ```


### PR DESCRIPTION
## Summary
- Updated main README.md with all available tools and their requirements
- Updated CLI README for update-core-repos.sh with new force-rebase option
- Added examples and comprehensive documentation for the -f/--force flag
- Updated the Features and Safety sections to mention intelligent rebasing

This PR adds documentation for the new feature added in #10 that intelligently skips rebasing when the master branch hasn't changed.

🤖 Generated with [Claude Code](https://claude.ai/code)